### PR TITLE
-added check for FCoE module

### DIFF
--- a/fcoe-target-setup.sh
+++ b/fcoe-target-setup.sh
@@ -21,6 +21,12 @@ MAC_FCOE_1=0c:fd:37:d4:44:7b
 VLAN_0=210
 VLAN_1=200
 
+##check if the FCoE module is loaded, otherwise terminate
+if ! lsmod | grep "fcoe" &> /dev/null; then
+    echo "FCoE module not found, please load the FCoE module first using \"modprobe fcoe"\"
+    exit 1
+fi
+
 gen_mac_address() {
     # This is the SUSE OUI
     OUI=0x0cfd37

--- a/setup_fcoe.sh
+++ b/setup_fcoe.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+##check if the FCoE module is loaded, otherwise terminate
+if ! lsmod | grep "fcoe" &> /dev/null; then
+    echo "FCoE module not found, please load the FCoE module first using \"modprobe fcoe"\"
+    exit 1
+fi
+
 gen_sas_address() {
     prefix="naa.6001405"
     uuid=$(uuidgen | sed 's/-//g' | tail --bytes 10)


### PR DESCRIPTION
Hi,

i just added a little check function, which looks for the FCoE module.
If the module is loaded, it continues with setting up the target and such stuff.
If the module is not present, it terminates and tells the user what to do.

Looks a little bit clearer in my opinion.

