### PR TITLE
- FCoE target check for setup_fcoe_single.sh

### DIFF
--- a/setup_fcoe_single.sh
+++ b/setup_fcoe_single.sh
@@ -6,6 +6,12 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
+##check if FCoE target exists, otherwise terminate
+if [ ! -d /sys/kernel/config/target/fc ]; then
+    echo "Please create a FCoE target first using "fcoe-target-setup"."
+    exit 1
+fi
+
 ##check if the FCoE module is loaded, otherwise terminate
 if ! lsmod | grep "fcoe" &> /dev/null; then
     echo "FCoE module not found, please load the FCoE module first using \"modprobe fcoe"\"


### PR DESCRIPTION
Hi,

stumbled across a little quirky thing here.
Until now one can run "setup_fcoe_single.sh" and "fcoe-target-setup.sh" in any random order.
So, if you first run "setup_fcoe_single.sh" and then "fcoe-target-setup.sh", only the backstores are shown in TargetCLI, which is a little bit confusing but also obvious, because "setup_fcoe_single.sh" has nothing to map the LUNs to.
So, if no target exists (e.g. directory under /sys/kernel/config/target/fc), setup_fcoe_single.sh won"t do anything until "fcoe-target-setup.sh" has been executed.